### PR TITLE
Use gcc package on Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,24 @@ env:
     - secure: "XY8WTyILZyTM+l8QWs2AK0/6bOK6O/rF5yqx/tQRZUS3gFU60aEd4L24vVMrTjBo+p2DZa+GW/+O6ge4PaOZe3AATPc8N7gArSIxS3umc8MATwOXX3RJ4PDeiE/zWDb60uTYJycOy2HGLhtcg+cw95cCGJOfXKG5JIjEmPFl8q1sWuR0If26SVkEzOdZRE253U14iZ0Bo8dbxCAQZgq/djY+4lbyPbklE0zeVzHBinNdorCG16e+50CKzlEm3ZMgOGBvC/FRNVfViMLIh8oVjmqfCq0eVwt90G4lXlbXzLJ4h/LaMHzI+k14x4xvjdGH/dCojkVwybolMIDB1TA9nCoYfThI6zb7Jb5YC7C496zAwCVaT4lEBJeB136YS7Iyl7ubnlKgactCfoe3N4YP443GBkYdtgIJ55p0yWwuebfpDcOXlgVsxjSUtQVnYAKYXvqAVaFBAZEoTjU9ymfYtFoZ+Ne2F5+mOTGDdcgl/JscW8MuiRxRqRY2oM7RPpZJz9DRQKMfj4KbjbzKIqpb8VOdiQIY2CRkmNaaFvkwVpn9B+zuc26D9nLeeko9o85V89iWSzHkgWI7aAn9ZXCOH7ckbCQ8ICnqdLZx1SONy1uK10OYZ2zALThMmuOh4bMAbrrqCYIGcgXSjy/KuzNXbjFPZMg4ry+vlDufcPj5otY="
 
 
-before install:
+before_install:
+    # Remove homebrew.
     - brew remove --force $(brew list)
+    - brew cleanup -s
+    - rm -rf $(brew --cache)
 
 install:
     - |
       MINICONDA_URL="http://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      wget "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
+      conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build jinja2 anaconda-client
+      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: http://primesieve.org/
 
 Package license: BSD 2-Clause
 
-Feedstock license: BSD
+Feedstock license: BSD 3-Clause
 
 Summary: Fast C/C++ prime number generator
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,11 +21,6 @@ environment:
 
   matrix:
     - TARGET_ARCH: x86
-      CONDA_PY: 27
-    - TARGET_ARCH: x64
-      CONDA_PY: 27
-
-    - TARGET_ARCH: x86
       CONDA_PY: 34
     - TARGET_ARCH: x64
       CONDA_PY: 34

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,11 @@ environment:
 
   matrix:
     - TARGET_ARCH: x86
+      CONDA_PY: 27
+    - TARGET_ARCH: x64
+      CONDA_PY: 27
+
+    - TARGET_ARCH: x86
       CONDA_PY: 34
     - TARGET_ARCH: x64
       CONDA_PY: 34
@@ -54,10 +59,15 @@ install:
     - cmd: set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%
     - cmd: set PYTHONUNBUFFERED=1
 
+    - cmd: conda config --set show_channel_urls true
     - cmd: conda install -c http://conda.binstar.org/pelson/channel/development --yes --quiet obvious-ci
     - cmd: conda config --add channels http://conda.binstar.org/conda-forge
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
+    # Workaround for Python 3.4 and x64 bug in latest conda-build.
+    # FIXME: Remove once there is a release that fixes the upstream issue
+    # ( https://github.com/conda/conda-build/issues/895 ).
+    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install conda-build=1.20.0 --yes
 
 # Skip .NET project specific build phase.
 build: off

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -20,7 +20,7 @@ channels:
 conda-build:
  root-dir: /feedstock_root/build_artefacts
 
-show_channel_urls: True
+show_channel_urls: true
 
 CONDARC
 )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   # Seem to be encountering hangs on Windows with Python 2.7; so, they are skipped.
   skip: true  # [win and py2k]
-  number: 1
+  number: 2
 
 build:
   features:
@@ -21,11 +21,11 @@ build:
 
 requirements:
   build:
-    - gcc     # [osx]
+    - gcc     # [unix]
     - python  # [win]
 
   run:
-    - libgcc  # [osx]
+    - libgcc  # [unix]
 
 test:
   requires:


### PR DESCRIPTION
Fixes https://github.com/conda-forge/primesieve-feedstock/issues/2

Adds the `gcc` package on Linux to allow OpenMP to be distributed. However, that may change in the future.

Also, re-rendered with `conda-smithy` 0.9.2.