### PR TITLE
Fix build number

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,7 @@ source:
 build:
   # Seem to be encountering hangs on Windows with Python 2.7; so, they are skipped.
   skip: true  # [win and py2k]
-  number: 2
-
-build:
+  number: 3
   features:
     - vc10              # [win and py34]
     - vc14              # [win and py35]


### PR DESCRIPTION
Fixes https://github.com/conda-forge/primesieve-feedstock/issues/4

Somehow we had two build sections. Ouch. This merges them. We also bumped the build number to distinguish it from any weird ones in case they build.