### PR TITLE
Fix re-render

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,14 +22,6 @@ environment:
       CONDA_PY: 35
       CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
-    - TARGET_ARCH: x86
-      CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda36
-
-    - TARGET_ARCH: x64
-      CONDA_PY: 36
-      CONDA_INSTALL_LOCN: C:\\Miniconda36-x64
-
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the TARGET_ARCH variable.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ build:
   features:
     - vc10              # [win and py34]
     - vc14              # [win and py35]
+    - vc14              # [win and py36]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   # Seem to be encountering hangs on Windows with Python 2.7; so, they are skipped.
-  skip: true  # [win and py2k]
+  skip: true  # [win and (py2k or py36)]
   number: 3
   features:
     - vc10              # [win and py34]


### PR DESCRIPTION
Drops Python 3.6 as it has the same VC as Python 3.5, which is already present. Also gears up for using Python 3.6 to accomplish this VC selection once it is relevant.